### PR TITLE
Add explicit check for inline disposition

### DIFF
--- a/src/main/java/app/unattach/model/EmailProcessor.java
+++ b/src/main/java/app/unattach/model/EmailProcessor.java
@@ -94,7 +94,7 @@ class EmailProcessor {
   }
 
   private boolean isDownloadableBodyPart(BodyPart bodyPart) throws MessagingException {
-    return bodyPart.getDisposition() != null;
+    return (bodyPart.getDisposition() != null && !"inline".equals(bodyPart.getDisposition()));
   }
 
   private void copyBodyPartToDisk(BodyPart bodyPart) throws IOException, MessagingException {


### PR DESCRIPTION
Apparently, some messages can have non-null disposition with the value "inline",
so update predicate in the isDownloadableBodyPart() check. 